### PR TITLE
Reorganize code

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,3 +1,15 @@
-@import "styles/syntax-variables.less";
-@import 'styles/editor.less';
-@import 'styles/language.less';
+@import (reference) "styles/syntax-variables";
+
+@import 'editor';
+@import 'language';
+
+@import 'languages/cs';
+@import 'languages/css';
+@import 'languages/gfm';
+@import 'languages/go';
+@import 'languages/ini';
+@import 'languages/java';
+@import 'languages/javascript';
+@import 'languages/json';
+@import 'languages/ruby';
+@import 'languages/python';

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -11,17 +11,17 @@
 @dark-gray:       #4f5b66;
 @very-dark-gray:  #272f3f;
 
-@cyan:     mix(@syntax-base-accent-color, hsl(178, 92%, 73%), @syntax-mix-percent);
-@blue:     mix(@syntax-base-accent-color, hsl(212, 99%, 73%), @syntax-mix-percent);
-@purple:   mix(@syntax-base-accent-color, hsl(286, 82%, 79%), @syntax-mix-percent);
-@green:    mix(@syntax-base-accent-color, hsl(118, 86%, 75%), @syntax-mix-percent);
-@red:      mix(@syntax-base-accent-color, hsl(358, 90%, 67%), @syntax-mix-percent);
-@yellow:   mix(@syntax-base-accent-color, hsl( 48, 81%, 76%), @syntax-mix-percent);
-@orange:   mix(@syntax-base-accent-color, hsl( 32, 91%, 72%), @syntax-mix-percent);
+@cyan:     mix(@syntax-accent, hsl(178, 92%, 73%), @syntax-mix-percent);
+@blue:     mix(@syntax-accent, hsl(212, 99%, 73%), @syntax-mix-percent);
+@purple:   mix(@syntax-accent, hsl(286, 82%, 79%), @syntax-mix-percent);
+@green:    mix(@syntax-accent, hsl(118, 86%, 75%), @syntax-mix-percent);
+@red:      mix(@syntax-accent, hsl(358, 90%, 67%), @syntax-mix-percent);
+@yellow:   mix(@syntax-accent, hsl( 48, 81%, 76%), @syntax-mix-percent);
+@orange:   mix(@syntax-accent, hsl( 32, 91%, 72%), @syntax-mix-percent);
 
 
 // Monochrome -----------------------------------
-@mono-1: mix(@syntax-base-accent-color, @light-gray, 2.5*@syntax-mix-percent); // default text
+@mono-1: mix(@syntax-accent, @light-gray, 2.5*@syntax-mix-percent); // default text
 @mono-2: @gray;
 @mono-3: @dark-gray;
 

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -4,21 +4,13 @@
 @syntax-brightness:   17%;
 @syntax-mix-percent:   8%;
 
-// Base colors -----------------------------------
-@syntax-base-accent-color:      hsl(@syntax-hue, 100%, 66%);
-@syntax-base-background-color:  hsl(@syntax-hue, @syntax-saturation, @syntax-brightness);
-@syntax-base-text-color:        mix(@syntax-base-accent-color, @light-gray, 2.5*@syntax-mix-percent);
-@syntax-comment-color:          mix(@syntax-base-accent-color, @dark-gray, 2.5*@syntax-mix-percent);
-@syntax-base-guide-color:       fade(@syntax-base-text-color, 15%);
-
-// Monochrome ------------------------------------
+// Colors -----------------------------------
 @very-light-gray: #c0c5ce;
 @light-gray:      #a7adba;
 @gray:            #65737e;
 @dark-gray:       #4f5b66;
 @very-dark-gray:  #272f3f;
 
-// Colors -----------------------------------
 @cyan:     mix(@syntax-base-accent-color, hsl(178, 92%, 73%), @syntax-mix-percent);
 @blue:     mix(@syntax-base-accent-color, hsl(212, 99%, 73%), @syntax-mix-percent);
 @purple:   mix(@syntax-base-accent-color, hsl(286, 82%, 79%), @syntax-mix-percent);
@@ -26,3 +18,27 @@
 @red:      mix(@syntax-base-accent-color, hsl(358, 90%, 67%), @syntax-mix-percent);
 @yellow:   mix(@syntax-base-accent-color, hsl( 48, 81%, 76%), @syntax-mix-percent);
 @orange:   mix(@syntax-base-accent-color, hsl( 32, 91%, 72%), @syntax-mix-percent);
+
+
+// Monochrome -----------------------------------
+@mono-1: mix(@syntax-base-accent-color, @light-gray, 2.5*@syntax-mix-percent); // default text
+@mono-2: @gray;
+@mono-3: @dark-gray;
+
+// Colors -----------------------------------
+@hue-1:   @cyan;
+@hue-2:   @blue;
+@hue-3:   @purple;
+@hue-4:   @green;
+@hue-5:   @red;
+@hue-5-2: darken(@red, 5%);
+@hue-6:   @orange;
+@hue-6-2: @yellow;
+
+
+// Base colors -----------------------------------
+@syntax-fg:     @mono-1;
+@syntax-bg:     hsl(@syntax-hue, @syntax-saturation, @syntax-brightness);
+@syntax-gutter: darken(@syntax-fg, 26%);
+@syntax-guide:  fade(@syntax-fg, 15%);
+@syntax-accent: hsl(@syntax-hue, 100%, 66%);

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -4,7 +4,14 @@
 @syntax-brightness:   17%;
 @syntax-mix-percent:   8%;
 
-// Colors -----------------------------------
+// Base colors -----------------------------------
+@syntax-fg:     @mono-1;
+@syntax-bg:     hsl(@syntax-hue, @syntax-saturation, @syntax-brightness);
+@syntax-gutter: darken(@syntax-fg, 26%);
+@syntax-guide:  fade(@syntax-fg, 15%);
+@syntax-accent: hsl(@syntax-hue, 100%, 66%);
+
+// Color definitions -----------------------------------
 @very-light-gray: #c0c5ce;
 @light-gray:      #a7adba;
 @gray:            #65737e;
@@ -34,11 +41,3 @@
 @hue-5-2: darken(@red, 5%);
 @hue-6:   @orange;
 @hue-6-2: @yellow;
-
-
-// Base colors -----------------------------------
-@syntax-fg:     @mono-1;
-@syntax-bg:     hsl(@syntax-hue, @syntax-saturation, @syntax-brightness);
-@syntax-gutter: darken(@syntax-fg, 26%);
-@syntax-guide:  fade(@syntax-fg, 15%);
-@syntax-accent: hsl(@syntax-hue, 100%, 66%);

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,3 +1,4 @@
+// Editor styles (background, gutter, guides)
 
 atom-text-editor, // <- remove when Shadow DOM can't be disabled
 :host {
@@ -23,7 +24,6 @@ atom-text-editor, // <- remove when Shadow DOM can't be disabled
   .bracket-matcher .region {
     border-bottom: 1px solid @syntax-cursor-color;
     box-sizing: border-box;
-    background-color: @syntax-bracket-matcher-background-color;
   }
 
   .invisible-character {
@@ -44,24 +44,10 @@ atom-text-editor, // <- remove when Shadow DOM can't be disabled
       color: @syntax-gutter-text-color;
       -webkit-font-smoothing: antialiased;
 
-      &.git-line-removed:before {
-        bottom: -3px;
-      }
-      &.git-line-removed:after {
-        content: "";
-        position: absolute;
-        left: 0px;
-        bottom: 0px;
-        width: 25px;
-        border-bottom: 1px dotted fade(@syntax-color-removed, 50%);
-        pointer-events: none;
-      }
-
       &.cursor-line {
         color: @syntax-gutter-text-color-selected;
         background-color: @syntax-gutter-background-color-selected;
       }
-
       &.cursor-line-no-selection {
         background-color: transparent;
       }
@@ -69,9 +55,20 @@ atom-text-editor, // <- remove when Shadow DOM can't be disabled
       .icon-right {
         color: @syntax-text-color;
       }
+    }
 
-      .icon-right {
-        color: @syntax-text-color;
+    &:not(.git-diff-icon) .line-number.git-line-removed {
+      &.git-line-removed::before {
+        bottom: -3px;
+      }
+      &::after {
+        content: "";
+        position: absolute;
+        left: 0px;
+        bottom: 0px;
+        width: 25px;
+        border-bottom: 1px dotted fade(@syntax-color-removed, 50%);
+        pointer-events: none;
       }
     }
   }

--- a/styles/language.less
+++ b/styles/language.less
@@ -1,266 +1,308 @@
-
 // Language syntax highlighting
 
 .comment {
-  color: @syntax-comment-color;
+  color: @mono-3;
   font-style: italic;
+
+  .markup.link {
+    color: @mono-3;
+  }
 }
 
 .entity {
 
   &.name.type {
-    color: @orange;
+    color: @hue-6-2;
   }
 
   &.other.inherited-class {
-    color: @green;
+    color: @hue-4;
   }
 }
 
 .keyword {
-  color: @purple;
+  color: @hue-3;
 
   &.control {
-    color: @purple;
+    color: @hue-3;
   }
 
   &.operator {
-    color: @syntax-text-color;
+    color: @mono-1;
   }
 
   &.other.special-method {
-    color: @blue;
+    color: @hue-2;
   }
 
   &.other.unit {
-    color: @orange;
+    color: @hue-6;
   }
 }
 
 .storage {
-  color: @purple;
+  color: @hue-3;
+
+  &.type {
+    &.annotation,
+    &.primitive {
+      color: @hue-3;
+    }
+  }
+
+  &.modifier {
+    &.package,
+    &.import {
+      color: @mono-1;
+    }
+  }
 }
 
 .constant {
-  color: @orange;
+  color: @hue-6;
+
+  &.variable {
+    color: @hue-6;
+  }
 
   &.character.escape {
-    color: @cyan;
+    color: @hue-1;
   }
 
   &.numeric {
-    color: @orange;
+    color: @hue-6;
   }
 
   &.other.color {
-    color: @cyan;
+    color: @hue-1;
   }
 
   &.other.symbol {
-    color: @cyan;
+    color: @hue-1;
   }
 }
 
 .variable {
-  color: @red;
+  color: @hue-5;
 
   &.interpolation {
-    color: @red;
+    color: @hue-5-2;
   }
 
-  &.parameter.function {
-    color: @syntax-text-color;
+  &.parameter {
+    color: @mono-1;
   }
-}
-
-.invalid.illegal {
-  background-color: @red;
-  color: @syntax-background-color;
 }
 
 .string {
-  color: @green;
+  color: @hue-4;
 
 
   &.regexp {
-    color: @cyan;
+    color: @hue-1;
 
     .source.ruby.embedded {
-      color: @orange;
+      color: @hue-6-2;
     }
   }
 
   &.other.link {
-    color: @red;
+    color: @hue-5;
   }
 }
 
 .punctuation {
   &.definition {
     &.comment {
-      color: @dark-gray;
+      color: @mono-3;
     }
 
+    &.method-parameters,
+    &.function-parameters,
     &.parameters,
+    &.separator,
+    &.seperator,
     &.array {
-      color: @syntax-text-color;
+      color: @mono-1;
     }
 
     &.heading,
     &.identity {
-      color: @blue;
+      color: @hue-2;
     }
 
     &.bold {
-      color: @orange;
+      color: @hue-6-2;
       font-weight: bold;
     }
 
     &.italic {
-      color: @purple;
+      color: @hue-3;
       font-style: italic;
     }
   }
 
-  &.section.embedded {
-    color: @red;
+  &.section {
+    &.embedded {
+      color: @hue-5-2;
+    }
+
+    &.method,
+    &.class,
+    &.inner-class {
+      color: @mono-1;
+    }
   }
 }
 
 .support {
   &.class {
-    color: @orange;
+    color: @hue-6-2;
+  }
+
+  &.type {
+    color: @hue-1;
   }
 
   &.function  {
-    color: @cyan;
+    color: @hue-1;
 
     &.any-method {
-      color: @blue;
+      color: @hue-2;
     }
   }
 }
 
 .entity {
-
   &.name.function {
-    color: @blue;
+    color: @hue-2;
   }
 
-  &.name.class, &.name.type.class {
-    color: @orange;
+  &.name.class,
+  &.name.type.class {
+    color: @hue-6-2;
   }
 
   &.name.section {
-    color: @blue;
+    color: @hue-2;
   }
 
   &.name.tag {
-    color: @red;
+    color: @hue-5;
   }
 
   &.other.attribute-name {
-    color: @orange;
+    color: @hue-6;
 
-    &.id,
-    &.mixin {
-      color: @blue;
+    &.id {
+      color: @hue-2;
     }
   }
 }
 
 .meta {
   &.class {
-    color: @orange;
+    color: @hue-6-2;
+
+    &.body {
+      color: @mono-1;
+    }
+  }
+
+  &.method-call,
+  &.method {
+    color: @mono-1;
+  }
+
+  &.definition {
+    &.variable {
+      color: @hue-5;
+    }
   }
 
   &.link {
-    color: @orange;
+    color: @hue-6;
   }
 
   &.require {
-    color: @blue;
+    color: @hue-2;
   }
 
   &.selector {
-    color: @purple;
+    color: @hue-3;
   }
 
   &.separator {
     background-color: #373b41;
-    color: @syntax-text-color;
+    color: @mono-1;
   }
 
   &.tag {
-    color: @syntax-text-color;
+    color: @mono-1;
   }
 }
 
+.underline {
+  text-decoration: underline;
+}
+
 .none {
-  color: @syntax-text-color;
+  color: @mono-1;
+}
+
+.invalid {
+  &.deprecated {
+    color: @syntax-deprecated-fg !important;
+    background-color: @syntax-deprecated-bg !important;
+  }
+  &.illegal {
+    color: @syntax-illegal-fg !important;
+    background-color: @syntax-illegal-bg !important;
+  }
 }
 
 // Languages -------------------------------------------------
 
 .markup {
   &.bold {
-    color: @orange;
+    color: @hue-6;
     font-weight: bold;
   }
 
   &.changed {
-    color: @purple;
+    color: @hue-3;
   }
 
   &.deleted {
-    color: @red;
+    color: @hue-5;
   }
 
   &.italic {
-    color: @purple;
+    color: @hue-3;
     font-style: italic;
   }
 
-  &.heading .punctuation.definition.heading {
-    color: @blue;
+  &.heading {
+    color: @hue-5;
+
+    .punctuation.definition.heading {
+      color: @hue-2;
+    }
+  }
+
+  &.link {
+    color: @hue-3;
   }
 
   &.inserted {
-    color: @green;
-  }
-
-  &.list {
-    color: @red;
+    color: @hue-4;
   }
 
   &.quote {
-    color: @orange;
+    color: @hue-6;
   }
 
-  &.raw.inline {
-    color: @green;
-  }
-}
-
-.source.gfm {
-  .markup {
-    -webkit-font-smoothing: auto;
-    &.heading {
-      color: @red;
-    }
-
-    &.link {
-      color: @purple;
-    }
-  }
-
-  .link .entity {
-    color: @blue;
-  }
-}
-
-.ruby {
-  &.symbol > .punctuation {
-    color: inherit;
+  &.raw {
+    color: @hue-4;
   }
 }

--- a/styles/languages/cs.less
+++ b/styles/languages/cs.less
@@ -1,0 +1,6 @@
+
+.source.cs {
+  .keyword.operator {
+    color: @hue-3;
+  }
+}

--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -1,0 +1,18 @@
+.source.css {
+
+  // highlight properties/values if they are supported
+  .property-name,
+  .property-value {
+    color: @mono-2;
+    &.support {
+      color: @mono-1;
+    }
+  }
+
+  &.less {
+    .mixin {
+      color: @hue-2;
+    }
+  }
+
+}

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -1,0 +1,9 @@
+.source.gfm {
+  .markup {
+    -webkit-font-smoothing: auto;
+  }
+
+  .link .entity {
+    color: @hue-2;
+  }
+}

--- a/styles/languages/go.less
+++ b/styles/languages/go.less
@@ -1,0 +1,5 @@
+.source.go {
+  .storage.type.string {
+      color: @hue-3
+  }
+}

--- a/styles/languages/ini.less
+++ b/styles/languages/ini.less
@@ -1,0 +1,5 @@
+.source.ini {
+  .keyword.other.definition.ini {
+    color: @hue-5;
+  }
+}

--- a/styles/languages/java.less
+++ b/styles/languages/java.less
@@ -1,0 +1,21 @@
+.source.java {
+  .storage {
+    &.modifier.import {
+      color: @hue-6-2;
+    }
+
+    &.type {
+      color: @hue-6-2;
+    }
+  }
+}
+
+.source.java-properties {
+  .meta.key-pair {
+    color: @hue-5;
+
+    & > .punctuation {
+      color: @mono-1;
+    }
+  }
+}

--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -1,0 +1,17 @@
+.source.js {
+  .keyword.operator {
+    color: @hue-1;
+
+    // keywords are definded in https://github.com/atom/language-javascript/blob/master/grammars/javascript.cson
+    // search "instanceof" for location
+    &.delete,
+    &.in,
+    &.of,
+    &.instanceof,
+    &.new,
+    &.typeof,
+    &.void {
+      color: @hue-3;
+    }
+  }
+}

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,0 +1,21 @@
+.source.json {
+  .meta.structure.dictionary.json {
+    & > .string.quoted.json {
+      & > .punctuation.string {
+        color: @hue-5;
+      }
+      color: @hue-5;
+    }
+  }
+
+  .meta.structure.dictionary.json, .meta.structure.array.json {
+    & > .value.json > .string.quoted.json,
+    & > .value.json > .string.quoted.json > .punctuation {
+      color: @hue-4;
+    }
+
+    & > .constant.language.json {
+      color: @hue-1;
+    }
+  }
+}

--- a/styles/languages/python.less
+++ b/styles/languages/python.less
@@ -1,0 +1,9 @@
+.source.python {
+  .keyword.operator.logical.python {
+    color: @hue-3;
+  }
+
+  .variable.parameter {
+    color: @hue-6;
+  }
+}

--- a/styles/languages/ruby.less
+++ b/styles/languages/ruby.less
@@ -1,0 +1,5 @@
+.source.ruby {
+  .constant.other.symbol > .punctuation {
+    color: inherit;
+  }
+}

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -25,6 +25,12 @@
 @syntax-gutter-background-color:          @syntax-bg; // unused
 @syntax-gutter-background-color-selected: lighten(@syntax-bg, 2%);
 
+// Git colors for git diff info.
+@syntax-color-renamed:  hsl(208, 100%, 60%);
+@syntax-color-added:    hsl(150,  60%, 54%);
+@syntax-color-modified: hsl(40,   60%, 70%);
+@syntax-color-removed:  hsl(0,    70%, 60%);
+
 // For language entity colors
 @syntax-color-variable:   @hue-5;
 @syntax-color-constant:   @hue-6;

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -3,33 +3,49 @@
 
 // Custom Syntax Variables -----------------------------------
 
-@syntax-cursor-line: hsla(@syntax-hue, 100%,  80%, .04); // needs to be semi-transparent to show search results
-@syntax-bracket-matcher-background-color: lighten(@syntax-background-color, 6%);
-
 // General colors
-@syntax-text-color:            @syntax-base-text-color;
-@syntax-cursor-color:          @syntax-base-accent-color;
+@syntax-text-color:            @syntax-fg;
+@syntax-cursor-color:          @syntax-accent;
 @syntax-selection-color:       lighten(@syntax-background-color, 10%);
-@syntax-selection-flash-color: @syntax-base-accent-color;
-@syntax-background-color:      @syntax-base-background-color;
+@syntax-selection-flash-color: @syntax-accent;
+@syntax-background-color:      @syntax-bg;
 
 // Guide colors
-@syntax-wrap-guide-color:          @syntax-base-guide-color;
-@syntax-indent-guide-color:        @syntax-base-guide-color;
-@syntax-invisible-character-color: @syntax-base-guide-color;
+@syntax-wrap-guide-color:          @syntax-guide;
+@syntax-indent-guide-color:        @syntax-guide;
+@syntax-invisible-character-color: @syntax-guide;
 
 // For find and replace markers
-@syntax-result-marker-color: @syntax-text-color;
-@syntax-result-marker-color-selected: @syntax-base-accent-color;
+@syntax-result-marker-color:          @syntax-fg;
+@syntax-result-marker-color-selected: @syntax-accent;
 
 // Gutter colors
-@syntax-gutter-text-color: darken(@syntax-text-color, 26%);
-@syntax-gutter-text-color-selected: @syntax-text-color;
-@syntax-gutter-background-color: @syntax-background-color; // unused
-@syntax-gutter-background-color-selected: lighten(@syntax-background-color, 2%);
+@syntax-gutter-text-color:                @syntax-gutter;
+@syntax-gutter-text-color-selected:       @syntax-fg;
+@syntax-gutter-background-color:          @syntax-bg; // unused
+@syntax-gutter-background-color-selected: lighten(@syntax-bg, 2%);
 
-// Git colors for git diff info.
-@syntax-color-renamed:  hsl(208, 100%, 60%);
-@syntax-color-added:    hsl(150,  60%, 54%);
-@syntax-color-modified: hsl(40,   60%, 70%);
-@syntax-color-removed:  hsl(0,    70%, 60%);
+// For language entity colors
+@syntax-color-variable:   @hue-5;
+@syntax-color-constant:   @hue-6;
+@syntax-color-property:   @syntax-fg;
+@syntax-color-value:      @syntax-fg;
+@syntax-color-function:   @hue-2;
+@syntax-color-method:     @hue-2;
+@syntax-color-class:      @hue-6-2;
+@syntax-color-keyword:    @hue-3;
+@syntax-color-tag:        @hue-5;
+@syntax-color-attribute:  @hue-6;
+@syntax-color-import:     @hue-3;
+@syntax-color-snippet:    @hue-4;
+
+
+// Custom Syntax Variables -----------------------------------
+// Don't use in packages
+
+@syntax-cursor-line: hsla(@syntax-hue, 100%,  80%, .04);
+
+@syntax-deprecated-fg: darken(@syntax-color-modified, 50%);
+@syntax-deprecated-bg: @syntax-color-modified;
+@syntax-illegal-fg:    white;
+@syntax-illegal-bg:    @syntax-color-removed;


### PR DESCRIPTION
This PR does a pretty big refactor of the code structure as far as language-specific highlighting goes. I took most of this from the way one-dark-syntax organizes their stuff (separate LESS partials for each language that has overrides).

As far as the colors being used, there are no changes there. This PR does bring the addition of some more complete highlighting.
