### PR TITLE
Update terminator puctuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.2
+* update semicolon/punctuation.terminator color
+
 ## 1.3.1
 * update screenshot and changelog
 

--- a/styles/language.less
+++ b/styles/language.less
@@ -153,6 +153,10 @@
       color: @mono-1;
     }
   }
+
+  &.terminator {
+    color: @mono-2;
+  }
 }
 
 .support {


### PR DESCRIPTION
This was being applied in CSS files, somewhat inadvertently, but I love how it looked and so this adds a rule to make all `.punctuation.terminator` elements a bit more faded. This applies to things like semicolons in CSS or JavaScript - characters that terminate a line of code.
