### PR TITLE
Refactor color vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.0
+* refactors color vars
+* removes `@syntax-mix-percent` calculations in favor of straight `hsl`
+* Brightens some colors
+
 ## 1.3.4
 * update keywords and engines in package.json
 

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -2,7 +2,21 @@
 @syntax-hue:          220;
 @syntax-saturation:   24%;
 @syntax-brightness:   17%;
-@syntax-mix-percent:   8%;
+
+// Monochrome -----------------------------------
+@mono-1:	hsl(221, 31%, 69%);
+@mono-2:	hsl(215, 22%, 49%);
+@mono-3:	hsl(216, 25%, 42%);
+
+// Colors -----------------------------------
+@hue-1:   hsl(182, 92%, 64%); // <- cyan
+@hue-2:   hsl(213, 99%, 72%); // <- blue
+@hue-3:   hsl(278, 83%, 79%); // <- purple
+@hue-4:   hsl(140, 88%, 69%); // <- green
+@hue-5:   hsl(354, 73%, 65%); // <- red
+@hue-5-2: hsl(354, 90%, 64%); // <- red 2
+@hue-6:   hsl( 31, 72%, 71%); // <- orange
+@hue-6-2: hsl( 57, 100%, 81%); // <- yellow
 
 // Base colors -----------------------------------
 @syntax-fg:     @mono-1;
@@ -10,34 +24,3 @@
 @syntax-gutter: darken(@syntax-fg, 26%);
 @syntax-guide:  fade(@syntax-fg, 15%);
 @syntax-accent: hsl(@syntax-hue, 100%, 66%);
-
-// Color definitions -----------------------------------
-@very-light-gray: #c0c5ce;
-@light-gray:      #a7adba;
-@gray:            #65737e;
-@dark-gray:       #4f5b66;
-@very-dark-gray:  #272f3f;
-
-@cyan:     mix(@syntax-accent, hsl(178, 96%, 73%), @syntax-mix-percent);
-@blue:     mix(@syntax-accent, hsl(212, 99%, 73%), @syntax-mix-percent);
-@purple:   mix(@syntax-accent, hsl(286, 82%, 79%), @syntax-mix-percent);
-@green:    mix(@syntax-accent, hsl(118, 96%, 75%), @syntax-mix-percent);
-@red:      mix(@syntax-accent, hsl(358, 90%, 67%), @syntax-mix-percent);
-@yellow:   mix(@syntax-accent, hsl( 48, 81%, 76%), @syntax-mix-percent);
-@orange:   mix(@syntax-accent, hsl( 32, 91%, 72%), @syntax-mix-percent);
-
-
-// Monochrome -----------------------------------
-@mono-1: mix(@syntax-accent, @light-gray, 2.5*@syntax-mix-percent); // default text
-@mono-2: mix(@syntax-accent, @gray, 2.5*@syntax-mix-percent);
-@mono-3: mix(@syntax-accent, @dark-gray, 2.5*@syntax-mix-percent);
-
-// Colors -----------------------------------
-@hue-1:   @cyan;
-@hue-2:   @blue;
-@hue-3:   @purple;
-@hue-4:   @green;
-@hue-5:   @red;
-@hue-5-2: darken(@red, 5%);
-@hue-6:   @orange;
-@hue-6-2: @yellow;


### PR DESCRIPTION
- removes `@syntax-mix-percent`
- removes unnecessary color variable declarations
- brightens some colors 🎨 
