### PR TITLE
Cyan links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.7.0
+* changes link color in markdown files to not be same color as italics text
+
+## 1.6.1
+* updates out-of-date screenshot in documentation
+
+## 1.6.0
+* supports `highlight-selected` package
+
 ## 1.5.0
 * Adds `syntax--` to all classes as part of the Shadow DOM removal
 

--- a/styles/syntax.less
+++ b/styles/syntax.less
@@ -3,6 +3,7 @@
   color: @mono-3;
   font-style: italic;
 
+  // make sure links are not colored inside of comments
   .syntax--markup.syntax--link {
     color: @mono-3;
   }
@@ -292,7 +293,7 @@
   }
 
   &.syntax--link {
-    color: @hue-3;
+    color: @hue-1;
   }
 
   &.syntax--inserted {


### PR DESCRIPTION
Links and italics text have the same color in markdown files. This makes the links be a different color.