### PR TITLE
Fix for Atom 1.22

### DIFF
--- a/styles/syntax.less
+++ b/styles/syntax.less
@@ -206,7 +206,8 @@
   &.syntax--class {
     color: @hue-6-2;
 
-    &.syntax--body {
+    &.syntax--body,
+    &.syntax--html {
       color: @mono-1;
     }
   }


### PR DESCRIPTION
The `language-html` package made some changes and based on that, the `=` following `class` in HTML was colored differently than all other equal signs. This overrides that behavior so it's consistent with the others.