### PR TITLE
add styles for bracket-matcher gutter line highlighting

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -92,6 +92,13 @@ atom-text-editor {
   .fold-marker:after {
     color: @syntax-gutter-text-color-selected;
   }
+  
+  .line-number {
+    &.bracket-matcher {
+      background-color: @syntax-bracket-matcher-bg;
+      color: @syntax-bracket-matcher-color;
+    }
+  }
 
 
   // Packages -----------------------------------

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -50,6 +50,8 @@
 // Don't use in packages
 
 @syntax-cursor-line: hsla(@syntax-hue, 100%,  80%, .04);
+@syntax-bracket-matcher-bg: hsla(@syntax-hue, 100%, 80%, .25);
+@syntax-bracket-matcher-color: hsl(@syntax-hue, 100%, 93%);
 
 @syntax-deprecated-fg: darken(@syntax-color-modified, 50%);
 @syntax-deprecated-bg: @syntax-color-modified;


### PR DESCRIPTION
With the [latest beta release](http://blog.atom.io/2017/10/03/atom-1-21.html#atom-122-beta), a feature was added to the `bracket-matcher` plugin to highlight the corresponding bracket line in the gutter. This PR adds styles so that it doesn't stick out like a sore thumb - the default styling clashes pretty hard with this theme.

**Potential down-sides:**
The contrast here might not be enough to stand out? I toyed around with using the blue cursor-color at 50% opacity so it would be obvious, but this seemed a little less intrusive, yet still helpful. Totally open to feedback here.