### PR TITLE
Add special highlighting for assignment operators

### DIFF
--- a/styles/syntax.less
+++ b/styles/syntax.less
@@ -28,6 +28,10 @@
 
   &.syntax--operator {
     color: @mono-1;
+    
+    &.syntax--assignment {
+      color: @hue-1;
+    }
   }
 
   &.syntax--other.syntax--special-method {

--- a/styles/syntax/javascript.less
+++ b/styles/syntax/javascript.less
@@ -2,7 +2,7 @@
   .syntax--keyword.syntax--operator {
     color: @hue-1;
 
-    // keywords are definded in https://github.com/atom/language-javascript/blob/master/grammars/javascript.syntax--cson
+    // keywords are defined in https://github.com/atom/language-javascript/blob/master/grammars/javascript.syntax--cson
     // search "instanceof" for location
     &.syntax--delete,
     &.syntax--in,


### PR DESCRIPTION
At some point, it appears the grammars added a `syntax--assignment` operator, and it looks like it styles the `=` in most languages. There was already mild support for this in some languages (such as JavaScript), barring any other conflicting classes, but this makes it consistent in all languages.

cc: @Lucid-Network, I believe this closes #22 - let me know!

## Examples:

*Ruby: before*
![image](https://user-images.githubusercontent.com/6248612/31874594-b613ee3a-b78f-11e7-82ef-470785c805ad.png)

*Ruby: after*
![image](https://user-images.githubusercontent.com/6248612/31874608-cbf2d04a-b78f-11e7-90f2-4f7cdac89c0d.png)


*Python: before*
![image](https://user-images.githubusercontent.com/6248612/31874640-f30b0a80-b78f-11e7-8879-cd6e500ba9fa.png)

*Python: after*
![image](https://user-images.githubusercontent.com/6248612/31874630-e4298b04-b78f-11e7-87fe-799e1476f3cb.png)
