### PR TITLE
Elixir function params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.13.0
+* adds syntax highlighting for Elixir function params for `one-dark-syntax` feature parity
+
 ## 1.12.0
 * fixes incorrect bracket color in PHP files
 * fixes TypeScript separator background color

--- a/styles/syntax/elixir.less
+++ b/styles/syntax/elixir.less
@@ -8,10 +8,14 @@
     color: @hue-2;
   }
   .syntax--variable.syntax--definition,
-  .syntax--variable.syntax--anonymous{
+  .syntax--variable.syntax--anonymous {
     color: @hue-3;
   }
-  .syntax--quoted{
+  .syntax--parameter.syntax--variable.syntax--function {
+    color: @hue-6;
+    font-style: italic;
+  }
+  .syntax--quoted {
     color: @hue-4;
   }
   .syntax--keyword.syntax--special-method,


### PR DESCRIPTION
to keep feature parity with `one-dark-syntax`