### PR TITLE
String interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+
+* prevents string syntax color from bleeding into values inside interpolated strings
+
 ## 2.2.0
 
 * brings back red for variable color. This ended up affecting a ton of stuff, and we need this to not be the same as the text color. Red still feels strong, but a lot of other themes are using red for this as well, so for now I'm just switching it back. Maybe someday I'll come back to this.

--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -104,6 +104,10 @@
 .syntax--string {
   color: @hue-4;
 
+  > .syntax--source {
+    color: @syntax-fg;
+  }
+
   &.syntax--regexp {
     color: @hue-1;
 

--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -105,7 +105,7 @@
   color: @hue-4;
 
   > .syntax--source {
-    color: @syntax-fg;
+    color: @mono-1;
   }
 
   &.syntax--regexp {


### PR DESCRIPTION
Prevents the string color from leaking into interpolated values. For example, in JavaScript:

```js
`this string has interpolation: ${getInterpolatedValue(yes)}`
```

In the above, `yes` would be highlighted the same color as a string, when it should be highlighted as a function parameter. This fixes that.